### PR TITLE
Refactor frontend to use Vite + React 19 with component architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 .vscode/
+.claude/
+.idea/
 /target
 /tmp
 /dist
 node_modules/
-package-lock.json
-package.json
-babel.config.json
-.idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Raffler is a web application for managing pinball games at locations. Users can track games at different locations, reserve games, add notes, and temporarily disable games. Stale reservations are automatically cleaned up after 90 minutes.
+
+## Tech Stack
+
+- **Backend**: Rust with Axum web framework, Tokio async runtime
+- **Database**: PostgreSQL with SQLx (compile-time verified queries)
+- **Frontend**: React 19 + React Bootstrap, built with Vite
+- **CI**: GitHub Actions (`.github/workflows/rust.yml`)
+
+## Common Commands
+
+### Backend
+```bash
+cargo build                  # Build
+cargo run                    # Build and run (serves on http://localhost:8000)
+cargo test                   # Run tests
+cargo clippy --all-targets --all-features -- -D warnings  # Lint
+cargo fmt -- --check         # Check formatting
+cargo fmt                    # Fix formatting
+```
+
+### Frontend
+```bash
+npm install                  # Install dependencies (required first time)
+npm run dev                  # Start Vite dev server with HMR (http://localhost:5173)
+npm run build                # Production build to dist/
+```
+
+### Database
+```bash
+export DATABASE_URL="postgres://localhost/raffler"
+sqlx database create         # Create database
+sqlx migrate run             # Run migrations (also runs automatically on app startup)
+```
+
+### CI builds (no database required)
+```bash
+SQLX_OFFLINE=true cargo build    # Uses cached queries from .sqlx/ directory
+SQLX_OFFLINE=true cargo test
+```
+
+## Development Workflow
+
+Two-terminal setup for development with hot reload:
+1. **Terminal 1**: `cargo run` (backend on :8000)
+2. **Terminal 2**: `npm run dev` (Vite dev server on :5173, proxies `/v1` to backend)
+
+Access http://localhost:5173 during development. The Vite proxy config is in `vite.config.js`.
+
+For production, the Rust server serves static files from `dist/` (or directory set by `STATIC_DIR` env var).
+
+## Architecture
+
+### Backend (3 files)
+
+- **`src/main.rs`**: Axum router setup, database pool, background cleanup task (releases reservations >90min every 15min)
+- **`src/api.rs`**: HTTP handlers — request/response types and endpoint implementations. Thin layer that delegates to `db.rs`
+- **`src/db.rs`**: Database models and SQLx queries. All queries use `query_as!` for compile-time checking
+
+### Frontend (`static/` directory)
+
+- **`raffler.jsx`**: Main React app component
+- **`api.js`**: API client for all backend calls
+- **`components/`**: React components organized by feature (game/, location/, modals/, shared/)
+- **`hooks/`**: Custom hooks — `useGames`, `useLocations`, `useGameOperations`, `useModal`
+- **`utils/formatting.js`**: Display formatting helpers
+
+### Data Model
+
+Hierarchical: **Location** → **Game** → **Note** (+ **Reservation** history per game)
+
+All entities use soft deletes (`deleted_at` timestamps). Deleting a location cascades soft-deletes to its games and notes within a transaction.
+
+Games track current reservation state via `reserved_at` on the game table. When released, a record is written to the `reservation` table for statistics. The `reserved_minutes` field is computed dynamically in SQL as `EXTRACT(EPOCH FROM (now() - reserved_at)) / 60`.
+
+The `player` table exists in the schema but is not used in the application.
+
+### API Routes
+
+REST routes nested under `/v1/locations`. Key patterns:
+- `POST .../games/reservations` — reserve a random unreserved game at a location
+- `POST .../games/{game_id}/reservations` — reserve a specific game
+- `DELETE .../games/{game_id}/reservations` — release a reservation
+- `POST .../games/{game_id}/disable` / `enable` — toggle game availability
+
+### SQLx Offline Mode
+
+The `.sqlx/` directory contains cached query metadata enabling builds without a live database (`SQLX_OFFLINE=true`). When modifying SQL queries, you need a running database to regenerate these with `cargo sqlx prepare`.
+
+## Known Issues
+
+- Some note/reservation endpoints accept `location_id` in the path but don't verify it against the game (see `_location_id` parameters in `src/api.rs`)

--- a/README.md
+++ b/README.md
@@ -1,70 +1,105 @@
 ### Raffler
 
-Nothing to see here yet. Move along.
+Web application for managing pinball games at locations. Users can track games, reserve games, add notes, and temporarily disable games. Stale reservations are automatically cleaned up after 90 minutes.
 
-#### Building/running
-Might require:
-`$ export DATABASE_URL="postgres://localhost/raffler"`
+#### Prerequisites
 
-To recreate db with sqlx-cli installed:
+- Rust toolchain
+- PostgreSQL
+- Node.js 20+ and npm
+
+#### Building
+
+Build the frontend (outputs to `dist/`):
 ```
-$ sqlx database drop
+$ npm install
+$ npm run build
+```
+
+Build the backend:
+```
+$ cargo build
+```
+
+#### Database setup
+
+Requires a running PostgreSQL instance:
+```
+$ export DATABASE_URL="postgres://localhost/raffler"
 $ sqlx database create
 $ sqlx migrate run
 ```
 
-To build:
+Migrations also run automatically on application startup.
 
-`$ cargo build`
+To build without a database (CI):
+```
+$ SQLX_OFFLINE=true cargo build
+```
 
-To build and run:
+#### Running
 
-`$ cargo run`
+Build the frontend first, then start the server:
+```
+$ npm run build
+$ cargo run
+```
+
+Open http://localhost:8000. The backend serves both the API and the frontend from `dist/`.
+
+#### Development
+
+For development with hot reload, use two terminals:
+
+1. `cargo run` (backend on http://localhost:8000)
+2. `npm run dev` (Vite dev server on http://localhost:5173, proxies `/v1` to backend)
+
+Access http://localhost:5173 during development.
 
 #### Testing
-Useful commands for testing service/API locally.
 
-##### Add location
-`$ curl -X POST http://localhost:8000/v1/locations -H 'Content-Type: application/json' -d '{"name":"Spola Tilten"}'`
+Backend tests:
+```
+$ SQLX_OFFLINE=true cargo test
+```
 
-##### List locations
-`$ curl http://localhost:8000/v1/locations`
+Linting:
+```
+$ cargo clippy --all-targets --all-features -- -D warnings
+$ cargo fmt -- --check
+```
 
-##### Delete location
-`$ curl -X DELETE http://localhost:8000/v1/locations/1`
+#### API
 
-##### List games at location
-`$ curl http://localhost:8000/v1/locations/1/games`
+Useful commands for testing the API locally.
 
-##### Add game at location
-`$ curl -X POST http://localhost:8000/v1/locations/1/games -H 'Content-Type: application/json' -d '{"name":"Attack From Mars", "abbreviation": "AFM"}'`
+##### Locations
+```
+$ curl http://localhost:8000/v1/locations
+$ curl -X POST http://localhost:8000/v1/locations -H 'Content-Type: application/json' -d '{"name":"Spola Tilten"}'
+$ curl -X DELETE http://localhost:8000/v1/locations/1
+```
 
-##### List information for game at location
-`$ curl http://localhost:8000/v1/locations/1/games/1`
+##### Games
+```
+$ curl http://localhost:8000/v1/locations/1/games
+$ curl http://localhost:8000/v1/locations/1/games/1
+$ curl -X POST http://localhost:8000/v1/locations/1/games -H 'Content-Type: application/json' -d '{"name":"Attack From Mars", "abbreviation": "AFM"}'
+$ curl -X PUT http://localhost:8000/v1/locations/1/games/1 -H 'Content-Type: application/json' -d '{"name":"Attack From Lars", "abbreviation": "AFL"}'
+$ curl -X DELETE http://localhost:8000/v1/locations/1/games/1
+$ curl -X POST http://localhost:8000/v1/locations/1/games/1/disable
+$ curl -X POST http://localhost:8000/v1/locations/1/games/1/enable
+```
 
-##### Update information for game at location
-`$ curl -X PUT http://localhost:8000/v1/locations/1/games/1 -H 'Content-Type: application/json' -d '{"name":"Attack From Lars", "abbreviation": "AFL"}'`
+##### Reservations
+```
+$ curl -X POST http://localhost:8000/v1/locations/1/games/1/reservations
+$ curl -X POST http://localhost:8000/v1/locations/1/games/reservations
+$ curl -X DELETE http://localhost:8000/v1/locations/1/games/1/reservations
+```
 
-##### Delete game at location
-`$ curl -X DELETE http://localhost:8000/v1/locations/1/games/1`
-
-#### Disabled game at location
-`curl -X POST http://localhost:8000/v1/locations/1/games/1/disable`
-
-#### Enable game at location
-`curl -X POST http://localhost:8000/v1/locations/1/games/1/enable`
-
-##### Add note to game at location
-`curl -X POST http://localhost:8000/v1/locations/1/games/1/notes -H 'Content-Type: application/json' -d '{"note":"Autoplunger is infested with cows"}'`
-
-##### Delete note for game at location
-`curl -X DELETE http://localhost:8000/v1/locations/1/games/1/notes/1`
-
-##### Reserve game at location
-`curl -X POST http://localhost:8000/v1/locations/1/games/1/reservations`
-
-#### Reserve random game at location
-`curl -X POST http://localhost:8000/v1/locations/1/games/reservations`
-
-##### Release reservation for game at location
-`curl -X DELETE http://localhost:8000/v1/locations/1/games/1/reservations`
+##### Notes
+```
+$ curl -X POST http://localhost:8000/v1/locations/1/games/1/notes -H 'Content-Type: application/json' -d '{"note":"Autoplunger is infested with cows"}'
+$ curl -X DELETE http://localhost:8000/v1/locations/1/games/1/notes/1
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,11 @@
-Frontend (crude beginning still):
-- Vendor dependencies (?) and figure out how to build production app
-- Add error handling (handle 404s etc) or fix API responses to not err as described below
-- Visual: Fix the note/comment display to include date/time and add controls for deleting them (if not there)
-- Make it possible to refresh the page and only reload game state?
-
 Backend:
 - We err when for example a game is reserved twice (IS NULL WHERE-clauses prevent mutation), maybe just return game state and 200?
-- API needs to be revisited once we build frontend
+- API needs to be revisited
     - Use HTTP status codes to signal outcomes (ex: Should we return things like 201 Created)
     - Game related requests don't really need location id (i.e. we could drop the location part from /locations/<id>/games/<id>)
     - Do we want to provide context around failures? As in some form of error object in responses?
+    - Some note/reservation endpoints accept location_id in the path but don't verify it against the game
 - Refactor db to re-use common queries etc... remove duplication... maybe... :reverse_shaking_fist:
     - For a blatant example see disable/enable
 - There's currently no validation of actions on deleted entities. Ex you can add games at deleted locations
-- We probably want to spawn some thread that does clean-up as in remove reservations older than N
+- No concurrency protection on mutations (e.g. concurrent reserves could race)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2147 @@
+{
+  "name": "raffler",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "raffler",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "bootstrap": "^5.3.8",
+        "react": "^19.2.4",
+        "react-bootstrap": "^2.10.10",
+        "react-dom": "^19.2.4"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^5.1.2",
+        "vite": "^7.3.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
+      "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@popperjs/core": "^2.11.8",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.5.0",
+        "@types/warning": "^3.0.3",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.4",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/@restart/hooks": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/uncontrollable": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.14.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
+      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
+      "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
+      "integrity": "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.5",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.53",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001767",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
+      "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.283",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
+      "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-bootstrap": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
+      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.9.4",
+        "@types/prop-types": "^15.7.12",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
+        "dom-helpers": "^5.2.1",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "prop-types-extra": "^1.1.0",
+        "react-transition-group": "^4.4.5",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.8",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "devDependencies": {
+    "@vitejs/plugin-react": "^5.1.2",
+    "vite": "^7.3.1"
+  },
+  "dependencies": {
+    "bootstrap": "^5.3.8",
+    "react": "^19.2.4",
+    "react-bootstrap": "^2.10.10",
+    "react-dom": "^19.2.4"
+  },
+  "name": "raffler",
+  "version": "1.0.0",
+  "description": "Nothing to see here yet. Move along.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sral/raffler.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "bugs": {
+    "url": "https://github.com/sral/raffler/issues"
+  },
+  "homepage": "https://github.com/sral/raffler#readme"
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "name": "raffler",
   "version": "1.0.0",
-  "description": "Nothing to see here yet. Move along.",
+  "description": "Web application for managing pinball games at locations",
   "main": "index.js",
   "directories": {
     "doc": "docs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn main() {
         Err(e) => tracing::debug!("Error {e}"),
     }
 
-    let serve_dir = ServeDir::new("static").not_found_service(ServeFile::new("static/index.html"));
+    let serve_dir = ServeDir::new("dist").not_found_service(ServeFile::new("dist/index.html"));
 
     let app = Router::new()
         .route(
@@ -128,7 +128,6 @@ async fn main() {
             "/v1/locations/{location_id}/games/{game_id}/notes/{note_id}",
             delete(api::delete_note_for_game_by_id),
         )
-        .nest_service("/assets", serve_dir.clone())
         .fallback_service(serve_dir)
         .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()))
         .with_state(pool);

--- a/static/api.js
+++ b/static/api.js
@@ -1,19 +1,39 @@
-const API_URL = 'http://localhost:8000';
-const API_VERSION = 'v1';
-const buildUrl = (path) => `${API_URL}/${API_VERSION}${path}`;
+import { DEFAULT_API_TIMEOUT_MS, STATS_API_TIMEOUT_MS } from './constants.js';
 
-const request = async (url, options) => {
+const API_VERSION = 'v1';
+const buildUrl = (path) => `/${API_VERSION}${path}`;
+
+// Request deduplication cache
+const pendingRequests = new Map();
+
+const request = async (url, options, timeout = DEFAULT_API_TIMEOUT_MS) => {
+  // Deduplicate only GET requests — mutations must never be collapsed
+  if (options.method === 'GET') {
+    const requestKey = `GET:${url}`;
+    if (pendingRequests.has(requestKey)) {
+      return pendingRequests.get(requestKey);
+    }
+
+    const promise = doFetch(url, options, timeout, requestKey);
+    pendingRequests.set(requestKey, promise);
+    return promise;
+  }
+
+  return doFetch(url, options, timeout, null);
+};
+
+const doFetch = async (url, options, timeout, requestKey) => {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
     const response = await fetch(url, {
       ...options,
       signal: controller.signal,
     });
-    
+
     clearTimeout(timeoutId);
-    
+
     if (!response.ok) {
       const error = new Error(
         `API Error: ${response.status} ${response.statusText} at ${url}`
@@ -21,7 +41,7 @@ const request = async (url, options) => {
       error.status = response.status;
       throw error;
     }
-    
+
     const contentType = response.headers.get('content-type');
     if (contentType && contentType.includes('application/json')) {
       return response.json();
@@ -34,15 +54,18 @@ const request = async (url, options) => {
     throw error;
   } finally {
     clearTimeout(timeoutId);
+    if (requestKey) {
+      pendingRequests.delete(requestKey);
+    }
   }
 };
 
 const createJsonOptions = (method, body = null) => ({
   method,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-  ...(body && { body: JSON.stringify(body) }),
+  ...(body && {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }),
 });
 
 export const API = {
@@ -56,42 +79,42 @@ export const API = {
       const url = buildUrl(`/locations/${locationId}/games`);
       return request(url, createJsonOptions('GET'));
     },
-    
+
     reserveRandom: async (locationId) => {
       const url = buildUrl(`/locations/${locationId}/games/reservations`);
       return request(url, createJsonOptions('POST'));
     },
-    
+
     reserve: async (locationId, gameId) => {
       const url = buildUrl(`/locations/${locationId}/games/${gameId}/reservations`);
       return request(url, createJsonOptions('POST'));
     },
-    
+
     release: async (locationId, gameId) => {
       const url = buildUrl(`/locations/${locationId}/games/${gameId}/reservations`);
       return request(url, createJsonOptions('DELETE'));
     },
-    
+
     remove: async (locationId, gameId) => {
       const url = buildUrl(`/locations/${locationId}/games/${gameId}`);
       return request(url, createJsonOptions('DELETE'));
     },
-    
+
     enable: async (locationId, gameId) => {
       const url = buildUrl(`/locations/${locationId}/games/${gameId}/enable`);
       return request(url, createJsonOptions('POST'));
     },
-    
+
     disable: async (locationId, gameId) => {
       const url = buildUrl(`/locations/${locationId}/games/${gameId}/disable`);
       return request(url, createJsonOptions('POST'));
     },
-    
+
     add: async (locationId, name, abbreviation) => {
       const url = buildUrl(`/locations/${locationId}/games`);
       return request(url, createJsonOptions('POST', { name, abbreviation }));
     },
-    
+
     update: async (locationId, gameId, name, abbreviation) => {
       const url = buildUrl(`/locations/${locationId}/games/${gameId}`);
       return request(url, createJsonOptions('PUT', { name, abbreviation }));
@@ -99,16 +122,16 @@ export const API = {
 
     getStats: async (locationId, gameId) => {
       const url = buildUrl(`/locations/${locationId}/games/${gameId}/reservations`);
-      return request(url, createJsonOptions('GET'));
+      return request(url, createJsonOptions('GET'), STATS_API_TIMEOUT_MS);
     },
   },
-  
+
   locations: {
     getAll: async () => {
       const url = buildUrl('/locations');
       return request(url, createJsonOptions('GET'));
     },
-    
+
     add: async (name) => {
       const url = buildUrl('/locations');
       return request(url, createJsonOptions('POST', { name }));

--- a/static/components/game/GameButton.jsx
+++ b/static/components/game/GameButton.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Button, ButtonGroup, Dropdown, DropdownButton, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { RESERVED_WARNING_THRESHOLD_MINUTES } from '../../constants.js';
+
+/**
+ * Individual game button with reserve/release and dropdown menu
+ */
+export const GameButton = React.memo(function GameButton({
+  game,
+  onButtonClick,
+  onToggleDisabled,
+  onRemove,
+  onShowDetails,
+  onShowStats,
+}) {
+  const { name, abbreviation, disabled_at, reserved_at, reserved_minutes } = game;
+
+  const isDisabled = Boolean(disabled_at);
+  const isReserved = Boolean(reserved_at);
+
+  const getButtonVariant = () => {
+    if (isDisabled) return 'secondary';
+    if (!isReserved) return 'success';
+    // If reserved for more than threshold, show yellow (warning)
+    if (reserved_minutes > RESERVED_WARNING_THRESHOLD_MINUTES) return 'warning';
+    // Otherwise show red (danger)
+    return 'danger';
+  };
+
+  const buttonVariant = getButtonVariant();
+  const buttonText = isReserved ? `${abbreviation} (${reserved_minutes}m)` : abbreviation;
+
+  const handleButtonClick = React.useCallback(() => {
+    if (!isDisabled) {
+      onButtonClick();
+    }
+  }, [isDisabled, onButtonClick]);
+
+  const handleToggleDisabled = React.useCallback((e) => {
+    e.stopPropagation();
+    onToggleDisabled();
+  }, [onToggleDisabled]);
+
+  const handleRemove = React.useCallback((e) => {
+    e.stopPropagation();
+    onRemove();
+  }, [onRemove]);
+
+  const handleShowDetails = React.useCallback((e) => {
+    e.stopPropagation();
+    onShowDetails();
+  }, [onShowDetails]);
+
+  const handleShowStats = React.useCallback((e) => {
+    e.stopPropagation();
+    onShowStats();
+  }, [onShowStats]);
+
+  return (
+    <OverlayTrigger placement="top" overlay={<Tooltip><strong>{name}</strong></Tooltip>}>
+      <ButtonGroup key={`buttongroup-${game.id}`} className="fixed-width-button mx-1 my-2">
+        <Button
+          title={name}
+          variant={buttonVariant}
+          disabled={isDisabled}
+          onClick={handleButtonClick}
+          aria-label={`${name} - ${isReserved ? `Reserved for ${reserved_minutes} minutes` : 'Available'}`}
+        >
+          {buttonText}
+        </Button>
+        <DropdownButton
+          variant={buttonVariant}
+          as={ButtonGroup}
+          id={`dropdown-${game.id}`}
+          drop="end"
+          aria-label={`Options for ${name}`}
+        >
+          <Dropdown.Item onClick={handleToggleDisabled}>
+            {isDisabled ? 'Enable' : 'Disable'}
+          </Dropdown.Item>
+          <Dropdown.Item onClick={handleRemove}>
+            Remove
+          </Dropdown.Item>
+          <Dropdown.Item onClick={handleShowDetails}>
+            Details
+          </Dropdown.Item>
+          <Dropdown.Item onClick={handleShowStats}>
+            Stats
+          </Dropdown.Item>
+        </DropdownButton>
+      </ButtonGroup>
+    </OverlayTrigger>
+  );
+});

--- a/static/components/game/GameList.jsx
+++ b/static/components/game/GameList.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Container } from 'react-bootstrap';
+import { GameButton } from './GameButton.jsx';
+import { PageLoader } from '../shared/LoadingSpinner.jsx';
+
+/**
+ * List of game buttons
+ */
+export const GameList = React.memo(function GameList({
+  games,
+  loading,
+  onGameClick,
+  onToggleDisabled,
+  onRemove,
+  onShowDetails,
+  onShowStats,
+}) {
+  if (loading) {
+    return <PageLoader />;
+  }
+
+  if (!games || games.length === 0) {
+    return (
+      <Container className="text-center mt-5">
+        <p className="text-muted">No games at this location yet. Add one to get started!</p>
+      </Container>
+    );
+  }
+
+  return (
+    <Container className="d-flex flex-wrap">
+      {games.map((game) => (
+        <GameButton
+          key={game.id}
+          game={game}
+          onButtonClick={() => onGameClick(game)}
+          onToggleDisabled={() => onToggleDisabled(game)}
+          onRemove={() => onRemove(game)}
+          onShowDetails={() => onShowDetails(game)}
+          onShowStats={() => onShowStats(game)}
+        />
+      ))}
+    </Container>
+  );
+});

--- a/static/components/game/RandomizeButton.jsx
+++ b/static/components/game/RandomizeButton.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+
+/**
+ * Button for reserving a random game
+ */
+export const RandomizeButton = React.memo(function RandomizeButton({ onClick, disabled = false }) {
+  return (
+    <Button
+      variant="primary"
+      onClick={onClick}
+      size="lg"
+      className="fixed-width-button mx-1 my-2"
+      disabled={disabled}
+      aria-label="Reserve random game"
+    >
+      Randomize!
+    </Button>
+  );
+});

--- a/static/components/location/LocationPicker.jsx
+++ b/static/components/location/LocationPicker.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Navbar, Container, Nav, NavDropdown } from 'react-bootstrap';
+
+/**
+ * Navigation bar with location selector and add game button
+ */
+export const LocationPicker = React.memo(function LocationPicker({
+  locations,
+  selectedLocation,
+  onSelectLocation,
+  onAddLocation,
+  onAddGame,
+}) {
+  const handleSelectLocation = React.useCallback((location) => {
+    onSelectLocation(location);
+  }, [onSelectLocation]);
+
+  const handleAddLocation = React.useCallback((e) => {
+    e.preventDefault();
+    onAddLocation();
+  }, [onAddLocation]);
+
+  const handleAddGame = React.useCallback((e) => {
+    e.preventDefault();
+    onAddGame();
+  }, [onAddGame]);
+
+  return (
+    <Navbar bg="light" expand="lg">
+      <Container>
+        <Navbar.Brand>{selectedLocation?.name || 'Select a location'}</Navbar.Brand>
+        <Navbar.Toggle aria-controls="basic-navbar-nav" />
+        <Navbar.Collapse id="basic-navbar-nav">
+          <Nav className="ms-auto">
+            {selectedLocation && (
+              <Nav.Link
+                href="#"
+                variant="outline-secondary"
+                onClick={handleAddGame}
+              >
+                Add game
+              </Nav.Link>
+            )}
+            <NavDropdown title="Locations" id="basic-nav-dropdown">
+              {locations.map((location) => (
+                <NavDropdown.Item
+                  key={location.id}
+                  href="#"
+                  onClick={() => handleSelectLocation(location)}
+                  active={selectedLocation?.id === location.id}
+                >
+                  {location.name}
+                </NavDropdown.Item>
+              ))}
+              <NavDropdown.Divider />
+              <NavDropdown.Item href="#" onClick={handleAddLocation}>
+                Add new location
+              </NavDropdown.Item>
+            </NavDropdown>
+          </Nav>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+});

--- a/static/components/modals/AddGameModal.jsx
+++ b/static/components/modals/AddGameModal.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Modal, Form, Button } from 'react-bootstrap';
+
+/**
+ * Modal for adding a new game to a location
+ */
+export function AddGameModal({
+  show,
+  onHide,
+  onAddGame,
+}) {
+  const [name, setName] = React.useState('');
+  const [abbreviation, setAbbreviation] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const handleClose = React.useCallback(() => {
+    setName('');
+    setAbbreviation('');
+    setError('');
+    onHide();
+  }, [onHide]);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!name.trim() || !abbreviation.trim()) {
+      setError('Both name and abbreviation are required.');
+      return;
+    }
+
+    try {
+      await onAddGame(name, abbreviation);
+      handleClose();
+    } catch (err) {
+      setError(err.message || 'Failed to add game');
+    }
+  }, [name, abbreviation, onAddGame, handleClose]);
+
+  return (
+    <Modal show={show} onHide={handleClose}>
+      <Modal.Header closeButton>
+        <Modal.Title>Add game</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {error && (
+          <div className="alert alert-danger" role="alert">
+            {error}
+          </div>
+        )}
+        <Form onSubmit={(e) => e.preventDefault()}>
+          <Form.Group className="mb-3" controlId="formAddGameAbbreviation">
+            <Form.Label>Enter game abbreviation</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Ex: IRMA"
+              value={abbreviation}
+              onChange={(e) => setAbbreviation(e.target.value)}
+              aria-label="Game abbreviation"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3" controlId="formAddGameName">
+            <Form.Label>Enter game name</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Ex: Iron Maiden (Stern)"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              aria-label="Game name"
+            />
+          </Form.Group>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          disabled={!name.trim() || !abbreviation.trim()}
+        >
+          Save
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/static/components/modals/AddLocationModal.jsx
+++ b/static/components/modals/AddLocationModal.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Modal, Form, Button } from 'react-bootstrap';
+
+/**
+ * Modal for adding a new location
+ */
+export function AddLocationModal({
+  show,
+  onHide,
+  onAddLocation,
+}) {
+  const [name, setName] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const handleClose = React.useCallback(() => {
+    setName('');
+    setError('');
+    onHide();
+  }, [onHide]);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!name.trim()) {
+      setError('Location name is required.');
+      return;
+    }
+
+    try {
+      await onAddLocation(name);
+      handleClose();
+    } catch (err) {
+      setError(err.message || 'Failed to add location');
+    }
+  }, [name, onAddLocation, handleClose]);
+
+  return (
+    <Modal show={show} onHide={handleClose}>
+      <Modal.Header closeButton>
+        <Modal.Title>Add new location</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {error && (
+          <div className="alert alert-danger" role="alert">
+            {error}
+          </div>
+        )}
+        <Form onSubmit={(e) => e.preventDefault()}>
+          <Form.Group className="mb-3" controlId="formAddLocation">
+            <Form.Label>Enter location name</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Ex: Special When Shit"
+              onChange={(e) => setName(e.target.value)}
+              value={name}
+              aria-label="Location name"
+            />
+          </Form.Group>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          disabled={!name.trim()}
+        >
+          Save
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/static/components/modals/ConfirmationModal.jsx
+++ b/static/components/modals/ConfirmationModal.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+
+/**
+ * Reusable confirmation dialog modal
+ */
+export function ConfirmationModal({
+  show,
+  onHide,
+  onConfirm,
+  title = 'Confirm Action',
+  message = 'Are you sure?',
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  variant = 'danger',
+}) {
+  const handleConfirm = () => {
+    onConfirm();
+    onHide();
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>{message}</Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onHide}>
+          {cancelText}
+        </Button>
+        <Button variant={variant} onClick={handleConfirm}>
+          {confirmText}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+/**
+ * Custom hook for managing confirmation dialogs
+ */
+export function useConfirmation() {
+  const [confirmState, setConfirmState] = React.useState({
+    show: false,
+    title: '',
+    message: '',
+    onConfirm: null,
+    confirmText: 'Confirm',
+    cancelText: 'Cancel',
+    variant: 'danger',
+  });
+
+  const showConfirmation = React.useCallback((options) => {
+    setConfirmState({
+      show: true,
+      title: options.title || 'Confirm Action',
+      message: options.message || 'Are you sure?',
+      onConfirm: options.onConfirm,
+      confirmText: options.confirmText || 'Confirm',
+      cancelText: options.cancelText || 'Cancel',
+      variant: options.variant || 'danger',
+    });
+  }, []);
+
+  const hideConfirmation = React.useCallback(() => {
+    setConfirmState((prev) => ({ ...prev, show: false }));
+  }, []);
+
+  const confirmationDialog = React.useMemo(() => (
+    <ConfirmationModal
+      show={confirmState.show}
+      onHide={hideConfirmation}
+      onConfirm={confirmState.onConfirm}
+      title={confirmState.title}
+      message={confirmState.message}
+      confirmText={confirmState.confirmText}
+      cancelText={confirmState.cancelText}
+      variant={confirmState.variant}
+    />
+  ), [confirmState, hideConfirmation]);
+
+  return {
+    showConfirmation,
+    hideConfirmation,
+    confirmationDialog,
+  };
+}

--- a/static/components/modals/GameDetailsModal.jsx
+++ b/static/components/modals/GameDetailsModal.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Modal, Form, Button } from 'react-bootstrap';
+import { Notes } from '../shared/Notes.jsx';
+import { useConfirmation } from './ConfirmationModal.jsx';
+
+/**
+ * Modal for viewing and adding game details/notes
+ */
+export function GameDetailsModal({
+  show,
+  onHide,
+  onExited,
+  game,
+  onAddNote,
+  onDeleteNote,
+}) {
+  const [noteText, setNoteText] = React.useState('');
+  const { showConfirmation, confirmationDialog } = useConfirmation();
+
+  const handleSubmit = React.useCallback(async (event) => {
+    event.preventDefault();
+    if (noteText.trim()) {
+      try {
+        await onAddNote(noteText);
+        setNoteText('');
+      } catch {
+        // Error already shown via toast; keep noteText for retry
+      }
+    }
+  }, [noteText, onAddNote]);
+
+  const handleDeleteNote = React.useCallback((noteId) => {
+    showConfirmation({
+      title: 'Delete Note',
+      message: 'Are you sure you want to delete this note?',
+      confirmText: 'Delete',
+      variant: 'danger',
+      onConfirm: () => onDeleteNote(noteId),
+    });
+  }, [showConfirmation, onDeleteNote]);
+
+  const handleClose = React.useCallback(() => {
+    setNoteText('');
+    onHide();
+  }, [onHide]);
+
+  return (
+    <Modal show={show} onHide={handleClose} onExited={onExited}>
+      {game && (
+        <>
+          <Modal.Header closeButton>
+            <Modal.Title>{game.name} ({game.abbreviation})</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            {confirmationDialog}
+            <Notes notes={game.notes} onDeleteNote={handleDeleteNote} />
+            <Form onSubmit={handleSubmit}>
+              <Form.Group className="mb-3" controlId="formAddNote">
+                <div className="d-flex gap-2">
+                  <Form.Control
+                    type="text"
+                    placeholder="Ex: Autoplunger is infested with cows"
+                    onChange={(e) => setNoteText(e.target.value)}
+                    value={noteText}
+                    aria-label="Note text"
+                  />
+                  <Button variant="primary" type="submit" disabled={!noteText.trim()}>
+                    Save
+                  </Button>
+                </div>
+              </Form.Group>
+            </Form>
+          </Modal.Body>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/static/components/modals/GameStatsModal.jsx
+++ b/static/components/modals/GameStatsModal.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Modal, Container, Row, Col, Table } from 'react-bootstrap';
+import { formatDuration } from '../../utils/formatting.js';
+
+/**
+ * Modal for displaying game reservation statistics
+ */
+export const GameStatsModal = React.memo(function GameStatsModal({
+  show,
+  onHide,
+  onExited,
+  stats,
+}) {
+  return (
+    <Modal show={show} onHide={onHide} onExited={onExited}>
+      {stats && (
+        <>
+          <Modal.Header closeButton>
+            <Modal.Title>Game Statistics</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Container>
+              <Row>
+                <Col>
+                  <h5>Reservation Statistics</h5>
+                  <Table striped bordered hover>
+                    <tbody>
+                      <tr>
+                        <td>Total Reservations</td>
+                        <td>{stats.reservation_count}</td>
+                      </tr>
+                      <tr>
+                        <td>Total Reserved Time</td>
+                        <td>{formatDuration(stats.reserved_minutes)}</td>
+                      </tr>
+                      <tr>
+                        <td>Average Reservation Time</td>
+                        <td>{Math.round(stats.average_reserved_minutes)} minutes</td>
+                      </tr>
+                      <tr>
+                        <td>Median Reservation Time</td>
+                        <td>{Math.round(stats.median_reserved_minutes)} minutes</td>
+                      </tr>
+                    </tbody>
+                  </Table>
+                </Col>
+              </Row>
+            </Container>
+          </Modal.Body>
+        </>
+      )}
+    </Modal>
+  );
+});

--- a/static/components/shared/LoadingSpinner.jsx
+++ b/static/components/shared/LoadingSpinner.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Spinner } from 'react-bootstrap';
+
+/**
+ * Loading spinner component
+ */
+export function LoadingSpinner({ size = 'sm', className = '' }) {
+  return (
+    <Spinner
+      animation="border"
+      size={size}
+      role="status"
+      className={className}
+    >
+      <span className="visually-hidden">Loading...</span>
+    </Spinner>
+  );
+}
+
+/**
+ * Full page loading spinner
+ */
+export function PageLoader() {
+  return (
+    <div className="d-flex justify-content-center align-items-center" style={{ minHeight: '200px' }}>
+      <Spinner animation="border" role="status">
+        <span className="visually-hidden">Loading...</span>
+      </Spinner>
+    </div>
+  );
+}

--- a/static/components/shared/Notes.jsx
+++ b/static/components/shared/Notes.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ListGroup, Button } from 'react-bootstrap';
+import { formatDateTime } from '../../utils/formatting.js';
+
+/**
+ * Notes display component with delete functionality
+ */
+export const Notes = React.memo(function Notes({ notes, onDeleteNote }) {
+  if (!notes || notes.length === 0) {
+    return null;
+  }
+
+  return (
+    <ListGroup variant="flush" className="notes-container mb-3">
+      {notes.map((note) => (
+        <ListGroup.Item key={note.id} className="note-item d-flex justify-content-between align-items-start">
+          <div className="flex-grow-1">
+            <span className="fw-bold">{formatDateTime(note.created_at)}: </span>
+            <span className="text-muted">{note.note}</span>
+          </div>
+          {onDeleteNote && (
+            <Button
+              variant="link"
+              size="sm"
+              className="text-danger p-0 ms-2"
+              onClick={() => onDeleteNote(note.id)}
+              aria-label="Delete note"
+            >
+              ×
+            </Button>
+          )}
+        </ListGroup.Item>
+      ))}
+    </ListGroup>
+  );
+});

--- a/static/components/shared/Toast.jsx
+++ b/static/components/shared/Toast.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Toast, ToastContainer } from 'react-bootstrap';
+import { TOAST_SUCCESS_DURATION_MS, TOAST_ERROR_DURATION_MS, SHOW_SUCCESS_TOASTS } from '../../constants.js';
+
+/**
+ * Toast notification component for displaying temporary messages
+ */
+export function ToastNotification({ show, onClose, message, variant = 'danger', delay = 5000 }) {
+  return (
+    <ToastContainer position="top-end" className="p-3" style={{ zIndex: 9999 }}>
+      <Toast show={show} onClose={onClose} delay={delay} autohide bg={variant}>
+        <Toast.Header>
+          <strong className="me-auto">
+            {variant === 'danger' ? 'Error' : variant === 'success' ? 'Success' : 'Info'}
+          </strong>
+        </Toast.Header>
+        <Toast.Body className={variant === 'danger' ? 'text-white' : ''}>
+          {message}
+        </Toast.Body>
+      </Toast>
+    </ToastContainer>
+  );
+}
+
+/**
+ * Custom hook for managing toast notifications
+ */
+let nextToastId = 0;
+
+export function useToast() {
+  const [toasts, setToasts] = React.useState([]);
+
+  const showToast = React.useCallback((message, variant = 'danger') => {
+    const id = nextToastId++;
+    setToasts((prev) => [...prev, { id, message, variant }]);
+  }, []);
+
+  const hideToast = React.useCallback((id) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showError = React.useCallback((message, error) => {
+    const errorMessage = error?.message ? `${message}: ${error.message}` : message;
+    showToast(errorMessage, 'danger');
+  }, [showToast]);
+
+  const showSuccess = React.useCallback((message) => {
+    if (SHOW_SUCCESS_TOASTS) {
+      showToast(message, 'success');
+    }
+  }, [showToast]);
+
+  const toastList = React.useMemo(() => {
+    return (
+      <ToastContainer position="top-end" className="p-3" style={{ zIndex: 9999 }}>
+        {toasts.map((toast) => {
+          // Success toasts auto-close after 1 second, errors after 5 seconds
+          const delay = toast.variant === 'success' ? TOAST_SUCCESS_DURATION_MS : TOAST_ERROR_DURATION_MS;
+
+          return (
+            <Toast
+              key={toast.id}
+              show={true}
+              onClose={() => hideToast(toast.id)}
+              delay={delay}
+              autohide
+              bg={toast.variant}
+            >
+              <Toast.Header>
+                <strong className="me-auto">
+                  {toast.variant === 'danger' ? 'Error' : toast.variant === 'success' ? 'Success' : 'Info'}
+                </strong>
+              </Toast.Header>
+              <Toast.Body className={toast.variant === 'danger' ? 'text-white' : ''}>
+                {toast.message}
+              </Toast.Body>
+            </Toast>
+          );
+        })}
+      </ToastContainer>
+    );
+  }, [toasts, hideToast]);
+
+  return {
+    showToast,
+    showError,
+    showSuccess,
+    toastList,
+  };
+}

--- a/static/constants.js
+++ b/static/constants.js
@@ -1,0 +1,12 @@
+// Time thresholds
+export const RESERVED_WARNING_THRESHOLD_MINUTES = 30;
+export const AUTO_RELEASE_TIMEOUT_MINUTES = 90;
+
+// API configuration
+export const DEFAULT_API_TIMEOUT_MS = 5000;
+export const STATS_API_TIMEOUT_MS = 15000; // Longer timeout for complex queries
+
+// Toast notification settings
+export const TOAST_SUCCESS_DURATION_MS = 1000; // Success toasts disappear quickly
+export const TOAST_ERROR_DURATION_MS = 5000;   // Errors stay visible longer
+export const SHOW_SUCCESS_TOASTS = false;       // Success is reflected in the UI; only show error toasts

--- a/static/hooks/useGames.js
+++ b/static/hooks/useGames.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { API } from '../api.js';
+
+/**
+ * Custom hook for managing games state and operations
+ * @param {number|null} locationId - The selected location ID
+ * @returns {Object} Games state and operations
+ */
+export function useGames(locationId) {
+  const [games, setGames] = React.useState([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+
+  const fetchGames = React.useCallback(async () => {
+    if (!locationId) {
+      setGames([]);
+      return;
+    }
+
+    try {
+      const fetchedGames = await API.games.getAll(locationId);
+      setGames(fetchedGames);
+    } catch (err) {
+      setError(err.message);
+      console.error('Failed to fetch games:', err);
+    }
+  }, [locationId]);
+
+  // Fetch games when location changes, with cancellation for rapid switches
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      if (!locationId) {
+        setGames([]);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const fetchedGames = await API.games.getAll(locationId);
+        if (!cancelled) {
+          setGames(fetchedGames);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err.message);
+          console.error('Failed to fetch games:', err);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => { cancelled = true; };
+  }, [locationId]);
+
+  // Optimistic update helper
+  const updateGameOptimistically = React.useCallback((gameId, updates) => {
+    setGames((prevGames) =>
+      prevGames.map((game) =>
+        game.id === gameId ? { ...game, ...updates } : game
+      )
+    );
+  }, []);
+
+  return {
+    games,
+    loading,
+    error,
+    fetchGames,
+    updateGameOptimistically,
+  };
+}

--- a/static/hooks/useLocations.js
+++ b/static/hooks/useLocations.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { API } from '../api.js';
+
+/**
+ * Custom hook for managing locations state
+ * @returns {Object} Locations state and operations
+ */
+export function useLocations() {
+  const [locations, setLocations] = React.useState([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+
+  const fetchLocations = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const fetchedLocations = await API.locations.getAll();
+      setLocations(fetchedLocations);
+    } catch (err) {
+      setError(err.message);
+      console.error('Failed to fetch locations:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Fetch locations on mount
+  React.useEffect(() => {
+    fetchLocations();
+  }, [fetchLocations]);
+
+  const addLocation = React.useCallback(async (name) => {
+    try {
+      const newLocation = await API.locations.add(name);
+      setLocations((prev) => [...prev, newLocation]);
+      return newLocation;
+    } catch (err) {
+      setError(err.message);
+      throw err;
+    }
+  }, []);
+
+  return {
+    locations,
+    loading,
+    error,
+    fetchLocations,
+    addLocation,
+  };
+}

--- a/static/hooks/useModal.js
+++ b/static/hooks/useModal.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+/**
+ * Custom hook for managing modal state
+ * @returns {Object} Modal state and control functions
+ */
+export function useModal() {
+  const [show, setShow] = React.useState(false);
+
+  const open = React.useCallback(() => setShow(true), []);
+  const close = React.useCallback(() => setShow(false), []);
+
+  return {
+    show,
+    open,
+    close,
+  };
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,18 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
+        <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="css/custom.css" />
-        <link rel="stylesheet" href="css/bootstrap.min.css" />
-        <!-- script crossorigin src="deps/react.production.min.js"></script -->
-        <!-- script crossorigin src="deps/react-dom.production.min.js"></script -->
-        <script src="deps/dev/react.development.js"></script>
-        <script src="deps/dev/react-dom.development.js"></script>
-        <script src="deps/react-bootstrap.min.js"></script>
-        <script src="deps/dev/babel.min.js"></script>
+        <title>Raffler</title>
+        <link rel="stylesheet" href="/css/custom.css" />
     </head>
     <body>
-        <div id="root"></div>  
-        <script type="text/babel" data-presets="react" data-type="module" src="raffler.jsx"></script>
+        <div id="root"></div>
+        <script type="module" src="/raffler.jsx"></script>
     </body>
 </html>

--- a/static/public/css/custom.css
+++ b/static/public/css/custom.css
@@ -1,0 +1,19 @@
+.fixed-width-button {
+    width: 200px;
+}
+
+.fixed-height-selected-game {
+    display: block;
+    height: 50px;
+    text-align: center;
+}
+
+.note-item {
+    word-break: break-word;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.notes-container {
+    padding: 0 12px;
+}

--- a/static/raffler.jsx
+++ b/static/raffler.jsx
@@ -1,620 +1,339 @@
-import {API} from './api.js';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import { API } from './api.js';
+import { useModal } from './hooks/useModal.js';
+import { useLocations } from './hooks/useLocations.js';
+import { useGames } from './hooks/useGames.js';
+import { useToast } from './components/shared/Toast.jsx';
+import { useConfirmation } from './components/modals/ConfirmationModal.jsx';
+import { LocationPicker } from './components/location/LocationPicker.jsx';
+import { RandomizeButton } from './components/game/RandomizeButton.jsx';
+import { GameList } from './components/game/GameList.jsx';
+import { AddLocationModal } from './components/modals/AddLocationModal.jsx';
+import { AddGameModal } from './components/modals/AddGameModal.jsx';
+import { GameDetailsModal } from './components/modals/GameDetailsModal.jsx';
+import { GameStatsModal } from './components/modals/GameStatsModal.jsx';
 
-// TODO: Clean this crap up once imports are fixed.
-const Button = ReactBootstrap.Button;
-const ButtonGroup = ReactBootstrap.ButtonGroup;
-const Col = ReactBootstrap.Col;
-const Container = ReactBootstrap.Container;
-const Dropdown = ReactBootstrap.Dropdown;
-const DropdownButton = ReactBootstrap.DropdownButton;
-const Form = ReactBootstrap.Form;
-const ListGroup = ReactBootstrap.ListGroup;
-const Modal = ReactBootstrap.Modal;
-const Nav = ReactBootstrap.Nav;
-const Navbar = ReactBootstrap.Navbar;
-const NavDropdown = ReactBootstrap.NavDropdown;
-const OverlayTrigger = ReactBootstrap.OverlayTrigger;
-const Row = ReactBootstrap.Row;
-const Tooltip = ReactBootstrap.Tooltip;
-const Table = ReactBootstrap.Table;
-
-const Event = {
-  Disable: 'disable',
-  Update: 'update',
-  Remove: 'remove',
-  Details: 'details',
-  Stats: 'stats',
-};
-
-function formatDuration(minutes) {
-  const days = Math.floor(minutes / (24 * 60));
-  const hours = Math.floor((minutes % (24 * 60)) / 60);
-  const mins = minutes % 60;
-
-  const parts = [];
-  if (days > 0) parts.push(`${days} day${days === 1 ? '' : 's'}`);
-  if (hours > 0) parts.push(`${hours} hour${hours === 1 ? '' : 's'}`);
-  if (mins > 0) parts.push(`${mins} minute${mins === 1 ? '' : 's'}`);
-
-  if (parts.length === 0) return '0 minutes';
-  if (parts.length === 1) return parts[0];
-  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
-  return `${parts[0]}, ${parts[1]} and ${parts[2]}`;
-}
-
-function Notes({ notes }) {
-  const formatDate = (timestamp) => {
-    const [date, time] = timestamp.replace('T', ' ').split(' ');
-    const [hour, minute] = time.split(':');
-    return `${date} ${hour}:${minute}`;
-  };
-
-  return (
-    <ListGroup variant="flush" className="notes-container">
-      {notes.map((note) => (
-        <ListGroup.Item key={note.id} className="note-item">
-          <span>{formatDate(note.created_at)}: </span>
-          <span className="text-muted">{note.note}</span>
-        </ListGroup.Item>
-      ))}
-    </ListGroup>
-  );
-}
-
-function GameDetailsModal({
-  gameDetails,
-  modalGameDetailsShow,
-  setGameDetails,
-  setModalGameDetailsShow,
-  selectedLocation,
-}) {
-  const [value, setValue] = React.useState('');
-
-  const onAddNote = async () => {
-    if (value.trim() !== '') {
-      const addedNote = await API.notes.add(selectedLocation.id, gameDetails.id, value);
-
-      setGameDetails((prevDetails) => {
-        const updatedDetails = { ...prevDetails };
-        if (!updatedDetails.notes) {
-          updatedDetails.notes = []; // Initialize notes array if it's empty
-        }
-        updatedDetails.notes.push(addedNote);
-        return updatedDetails;
-      });
-    }
-
-    setValue('');
-  };
-
-  const onInput = (event) => {
-    const inputValue = event.target.value;
-    setValue(inputValue);
-  };
-
-  const onSubmit = (event) => {
-    event.preventDefault();
-    onAddNote();
-  };
-
-  const onClose = () => {
-    setModalGameDetailsShow(false);
-    setGameDetails(null);
-  };
-
-  return (
-    <Modal show={modalGameDetailsShow} onHide={onClose}>
-      <Modal.Header closeButton>
-        <Modal.Title>{gameDetails?.name || ''} ({gameDetails?.abbreviation || ''})</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        {gameDetails?.notes && gameDetails.notes.length > 0 && <Notes notes={gameDetails.notes} />}
-        <Form onSubmit={onSubmit}>
-          <Form.Group className="mb-3" controlId="formAddNote">
-            <div className="d-flex">
-              <Form.Control
-                type="text"
-                placeholder="Ex: Autoplunger is infested with cows"
-                onChange={onInput}
-                value={value}
-              />
-              <Button variant="primary" type="submit">Save</Button>
-            </div>
-          </Form.Group>
-        </Form>
-      </Modal.Body>
-    </Modal>
-  );
-}
-
-function GameStatsModal({
-  modalGameStatsShow,
-  setModalGameStatsShow,
-  gameStats,
-}) {
-  if (!gameStats) {
-    return null;
-  }
-
-  return (
-    <Modal show={modalGameStatsShow} onHide={() => setModalGameStatsShow(false)}>
-      <Modal.Header closeButton>
-        <Modal.Title>Game Statistics</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Container>
-          <Row>
-            <Col>
-              <h5>Reservation Statistics</h5>
-              <Table striped bordered hover>
-                <tbody>
-                  <tr>
-                    <td>Total Reservations</td>
-                    <td>{gameStats.reservation_count}</td>
-                  </tr>
-                  <tr>
-                    <td>Total Reserved Time</td>
-                    <td>{formatDuration(gameStats.reserved_minutes)}</td>
-                  </tr>
-                  <tr>
-                    <td>Average Reservation Time</td>
-                    <td>{Math.round(gameStats.average_reserved_minutes)} minutes</td>
-                  </tr>
-                  <tr>
-                    <td>Median Reservation Time</td>
-                    <td>{Math.round(gameStats.median_reserved_minutes)} minutes</td>
-                  </tr>
-                </tbody>
-              </Table>
-            </Col>
-          </Row>
-        </Container>
-      </Modal.Body>
-    </Modal>
-  );
-}
-
-function AddLocationModal({
-  modalAddLocationShow,
-  setModalAddLocationShow,
-  setLocations,
-  setSelectedLocation,
-  setReservedGame,
-}) {
-  const [value, setValue] = React.useState('');
-
-  const onInput = (event) => setValue(event.target.value);
-  const onSubmit = (event) => event.preventDefault();
-  const onClose = () => {
-    setValue('');
-    setModalAddLocationShow(false);
-  };
-
-  async function onAddLocation(event) {
-    if (value) {
-      try {
-        const newLocation = await API.locations.add(value);
-        setSelectedLocation(newLocation);
-        setLocations((locations) => [...locations, newLocation]);
-        setValue('');
-        setReservedGame(null);
-        setModalAddLocationShow(false);
-      } catch (error) {
-        console.error('Error adding location', error);
-      }
-    }
-  }
-
-  return (
-    <Modal show={modalAddLocationShow} onHide={onClose}>
-      <Modal.Header closeButton>
-        <Modal.Title>Add new location</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Form onSubmit={onSubmit}>
-          <Form.Group className="mb-3" controlId="formAddLocation">
-            <Form.Label>Enter location name</Form.Label>
-            <Form.Control
-              type="text"
-              placeholder="Ex: Special When Shit"
-              onChange={onInput}
-              value={value}
-            />
-          </Form.Group>
-        </Form>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button variant="primary" onClick={onAddLocation}>
-          Save
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  );
-}
-
-function AddGameModal({ modalAddGameShow, selectedLocation, setModalAddGameShow, setGameStates }) {
-  const [name, setName] = React.useState('');
-  const [abbreviation, setAbbreviation] = React.useState('');
-
-  const handleInputName = (event) => setName(event.target.value);
-  const handleInputAbbreviation = (event) => setAbbreviation(event.target.value);
-  const handleClose = () => {
-    setName('');
-    setAbbreviation('');
-    setModalAddGameShow(false);
-  };
-
-  const handleAddGame = async () => {
-    if (!name.trim() || !abbreviation.trim()) {
-      console.error('Both name and abbreviation are required.');
-      return;
-    }
-
-    try {
-      await API.games.add(selectedLocation.id, name, abbreviation);
-      setGameStates(await API.games.getAll(selectedLocation.id));
-      setName('');
-      setAbbreviation('');
-      setModalAddGameShow(false);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  return (
-    <Modal show={modalAddGameShow} onHide={handleClose}>
-      <Modal.Header closeButton>
-        <Modal.Title>Add game</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Form onSubmit={(event) => event.preventDefault()}>
-          <Form.Group className="mb-3" controlId="formAddGameAbbreviation">
-            <Form.Label>Enter game abbreviation</Form.Label>
-            <Form.Control
-              type="text"
-              placeholder="Ex: IRMA"
-              value={abbreviation}
-              onChange={handleInputAbbreviation}
-            />
-          </Form.Group>
-
-          <Form.Group className="mb-3" controlId="formAddGameName">
-            <Form.Label>Enter game name</Form.Label>
-            <Form.Control
-              type="text"
-              placeholder="Ex: Iron Maiden (Stern)"
-              value={name}
-              onChange={handleInputName}
-            />
-          </Form.Group>
-        </Form>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={handleClose}>
-          Cancel
-        </Button>
-        <Button variant="primary" onClick={handleAddGame}>
-          Save
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  );
-}
-
-function LocationPicker({ locations, selectedLocation, onSelectLocationClick, onAddLocationClick, onAddGameClick }) {
-  const renderAddGameButton = () => {
-    if (!selectedLocation) {
-      return null;
-    }
-
-    return (
-      <Nav.Link
-        href="#"
-        variant="outline-secondary"
-        onClick={onAddGameClick}
-      >
-        Add game
-      </Nav.Link>
-    );
-  };
-
-  const renderLocationsDropdown = () => (
-    <NavDropdown title="Locations" id="basic-nav-dropdown">
-      {locations.map(location => (
-        <NavDropdown.Item
-          key={location.id}
-          href="#"
-          onClick={() => onSelectLocationClick(location)}
-        >
-          {location.name}
-        </NavDropdown.Item>
-      ))}
-      <NavDropdown.Divider />
-      <NavDropdown.Item href="#" onClick={onAddLocationClick}>
-        Add new location
-      </NavDropdown.Item>
-    </NavDropdown>
-  );
-
-  return (
-    <Navbar bg="light" expand="lg">
-      <Container>
-        <Navbar.Brand>{selectedLocation?.name}</Navbar.Brand>
-        <Navbar.Toggle aria-controls="basic-navbar-nav" />
-        <Navbar.Collapse id="basic-navbar-nav">
-          <Nav className="ms-auto">
-            {renderAddGameButton()}
-            {renderLocationsDropdown()}
-          </Nav>
-        </Navbar.Collapse>
-      </Container>
-    </Navbar>
-  );
-}
-
-function RandomizeButton({ onRaffleClick }) {
-  return (
-    <Button variant='primary' onClick={onRaffleClick} size='lg' className='fixed-width-button mx-1 my-2'>
-      Randomize!
-    </Button>
-  );
-}
-
-function GameButton({ game, onButtonClick, onToggleGameDisabledClick, onRemoveGameClick, onGameDetailsClick, onGameStatsClick }) {
-  const { name, abbreviation, disabled_at, reserved_at, reserved_minutes } = game;
-
-  const isDisabled = Boolean(disabled_at);
-  const isReserved = Boolean(reserved_at);
-
-  const getButtonVariant = () => {
-    if (isDisabled) return 'secondary';
-     if (!isReserved) return 'success';
-    // If reserved for more than 30 minutes, show yellow (warning)
-    if (reserved_minutes > 30) return 'warning';
-    // Otherwise show red (danger)
-    return 'danger';
-  };
-
-  const buttonVariant = getButtonVariant();  const buttonText = isReserved ? `${abbreviation} (${reserved_minutes}m)` : abbreviation;
-
-  const handleButtonClick = () => {
-    if (!isDisabled) {
-      onButtonClick();
-    }
-  };
-
-  return (
-    <OverlayTrigger placement='top' overlay={<Tooltip><strong>{name}</strong></Tooltip>}>
-      <ButtonGroup key={`buttongroup-${game.id}`} className="fixed-width-button mx-1 my-2">
-        <Button title={name} variant={buttonVariant} disabled={isDisabled} onClick={handleButtonClick}>
-          {buttonText}
-        </Button>
-        <DropdownButton variant={buttonVariant} as={ButtonGroup} id='bg-nested-dropdown' drop='end'>
-          <Dropdown.Item eventKey={Event.Disable} onClick={onToggleGameDisabledClick}>
-            {isDisabled ? 'Enable' : 'Disable'}
-          </Dropdown.Item>
-          <Dropdown.Item eventKey={Event.Remove} onClick={onRemoveGameClick}>Remove</Dropdown.Item>
-          <Dropdown.Item eventKey={Event.Details} onClick={onGameDetailsClick}>Details</Dropdown.Item>
-          <Dropdown.Item eventKey={Event.Stats} onClick={onGameStatsClick}>Stats</Dropdown.Item>
-        </DropdownButton>
-      </ButtonGroup>
-    </OverlayTrigger>
-  );
-}
-
-function GameList({ gameStates, selectedLocation, onGameClick, onToggleGameDisabledClick, onRemoveGameClick, onGameDetailsClick, onGameStatsClick }) {
-  return (
-    <Container fluid='md'>
-      <Row>
-        <Col>
-          {gameStates.map((game, index) => (
-            <GameButton
-              key={game.id}
-              game={game}
-              onButtonClick={() => onGameClick(index)}
-              onToggleGameDisabledClick={() => onToggleGameDisabledClick(selectedLocation, game)}
-              onRemoveGameClick={() => onRemoveGameClick(selectedLocation, game)}
-              onGameDetailsClick={() => onGameDetailsClick(selectedLocation, game)}
-              onGameStatsClick={() => onGameStatsClick(selectedLocation, game)}
-            />
-          ))}
-        </Col>
-      </Row>
-    </Container>
-  );
-}
-
-function Raffler() {
-  const [locations, setLocations] = React.useState([]);
+/**
+ * Main Raffler application component
+ */
+export function Raffler() {
+  // Location state
+  const { locations, addLocation } = useLocations();
   const [selectedLocation, setSelectedLocation] = React.useState(null);
+
+  // Game state
+  const {
+    games,
+    loading: gamesLoading,
+    error: gamesError,
+    fetchGames,
+    updateGameOptimistically,
+  } = useGames(selectedLocation?.id);
+
+  // Ref for selectedLocation so async callbacks always read the current value
+  const selectedLocationRef = React.useRef(selectedLocation);
+  selectedLocationRef.current = selectedLocation;
+
   const [reservedGame, setReservedGame] = React.useState(null);
-  const [gameStates, setGameStates] = React.useState([]);
   const [gameDetails, setGameDetails] = React.useState(null);
   const [gameStats, setGameStats] = React.useState(null);
 
   // Modals
-  const [modalAddLocationShow, setModalAddLocationShow] = React.useState(false);
-  const [modalAddGameShow, setModalAddGameShow] = React.useState(false);
-  const [modalGameDetailsShow, setModalGameDetailsShow] = React.useState(false);
-  const [modalGameStatsShow, setModalGameStatsShow] = React.useState(false);
+  const addLocationModal = useModal();
+  const addGameModal = useModal();
+  const gameDetailsModal = useModal();
+  const gameStatsModal = useModal();
 
-  React.useEffect(() => {
-    const getLocations = async () => {
-      setLocations(await API.locations.getAll());
+  // Toast notifications
+  const { showError, showSuccess, toastList } = useToast();
+
+  // Confirmation dialog
+  const { showConfirmation, confirmationDialog } = useConfirmation();
+
+  // Handler: Select location
+  const handleSelectLocation = React.useCallback((location) => {
+    if (selectedLocation?.id === location.id) {
+      return; // Don't update if location doesn't change
     }
-
-    getLocations();
-  }, []);
-
-  React.useEffect(() => {
-    const getGameStates = async () => {
-      if (selectedLocation) {
-        setGameStates(await API.games.getAll(selectedLocation.id));
-      }
-    }
-
-    getGameStates();
-  }, [selectedLocation]);
-
-
-  async function onRandomizeClick() {
-    setReservedGame(await API.games.reserveRandom(selectedLocation.id));
-    // Wasteful! This round-trip could be avoided and only the
-    // affected game could be updated. On the plus side this
-    // probably helps keep UI slightly more in sync if we have
-    // concurrent user fiddling with things.
-    setGameStates(await API.games.getAll(selectedLocation.id));
-  }
-
-  async function onGameClick(i) {
-    const game = gameStates[i];
-
-    if (game.reserved_at) {
-      await API.games.release(selectedLocation.id, game.id);
-    } else {
-      await API.games.reserve(selectedLocation.id, game.id);
-      setReservedGame(game);
-    }
-    // Wasteful! This roundtrip could be avoided and only the
-    // affected game could be updated. On the plus side this
-    // probably helps keep UI slightly more in sync if we have
-    // concurrent user fiddling with things.
-    setGameStates(await API.games.getAll(selectedLocation.id));
-  }
-
-  function onSelectLocationClick(location) {
-    if (selectedLocation && location.id === selectedLocation.id) {
-      // Don't update if location doesn't change.
-      return;
-    }
-
     setReservedGame(null);
     setSelectedLocation(location);
-  }
+  }, [selectedLocation]);
 
-  function onAddLocationClick() {
-    setModalAddLocationShow(true);
-  }
+  // Handler: Add location
+  const handleAddLocation = React.useCallback(async (name) => {
+    try {
+      const newLocation = await addLocation(name);
+      setSelectedLocation(newLocation);
+      setReservedGame(null);
+      showSuccess('Location added successfully');
+    } catch (error) {
+      showError('Failed to add location', error);
+      throw error;
+    }
+  }, [addLocation, showSuccess, showError]);
 
-  function onAddGameClick() {
-    setModalAddGameShow(true);
-  }
+  // Handler: Add game
+  const handleAddGame = React.useCallback(async (name, abbreviation) => {
+    if (!selectedLocation) return;
 
-  async function onGameDetailsClick(location, game) {
-    setGameDetails(await API.games.get(location.id, game.id));
-    setModalGameDetailsShow(true);
-  }
+    try {
+      await API.games.add(selectedLocation.id, name, abbreviation);
+      await fetchGames();
+      showSuccess('Game added successfully');
+    } catch (error) {
+      showError('Failed to add game', error);
+      throw error;
+    }
+  }, [selectedLocation, fetchGames, showSuccess, showError]);
 
-  async function onRemoveGameClick(location, game) {
-    if (!window.confirm("Are you sure?")) {
-      return;
+  // Handler: Reserve/Release game
+  const handleGameClick = React.useCallback(async (game) => {
+    if (!selectedLocation) return;
+
+    const isReserved = Boolean(game.reserved_at);
+
+    // Optimistic update
+    if (isReserved) {
+      updateGameOptimistically(game.id, {
+        reserved_at: null,
+        reserved_minutes: null,
+      });
+      setReservedGame((prev) => prev?.id === game.id ? null : prev);
+    } else {
+      updateGameOptimistically(game.id, {
+        reserved_at: new Date().toISOString(),
+        reserved_minutes: 0,
+      });
+      setReservedGame(game);
     }
 
-    await API.games.remove(location.id, game.id);
-    // Wasteful! This roundtrip could be avoided and only the
-    // affected game could be updated. On the plus side this
-    // probably helps keep UI slightly more in sync if we have
-    // concurrent user fiddling with things.
-    setGameStates(await API.games.getAll(selectedLocation.id));
-  }
+    try {
+      if (isReserved) {
+        await API.games.release(selectedLocation.id, game.id);
+      } else {
+        await API.games.reserve(selectedLocation.id, game.id);
+      }
+    } catch (error) {
+      showError(`Failed to ${isReserved ? 'release' : 'reserve'} game`, error);
+    }
+    // Always sync with server — if mutation failed, corrects the optimistic state
+    await fetchGames();
+  }, [selectedLocation, updateGameOptimistically, fetchGames, showError]);
 
-  async function onToggleGameDisabledClick(location, game) {
+  // Handler: Toggle game disabled
+  const handleToggleDisabled = React.useCallback(async (game) => {
+    if (!selectedLocation) return;
+
     const isDisabled = Boolean(game.disabled_at);
     const isReserved = Boolean(game.reserved_at);
 
-    if (isDisabled) {
-      await API.games.enable(location.id, game.id);
-    } else {
-      if (isReserved) {
-        await API.games.release(location.id, game.id);
-      }
-      await API.games.disable(location.id, game.id);
-    }
-    // Wasteful! This roundtrip could be avoided and only the
-    // affected game could be updated. On the plus side this
-    // probably helps keep UI slightly more in sync if we have
-    // concurrent user fiddling with things.
-    setGameStates(await API.games.getAll(selectedLocation.id));
-  }
+    // Optimistic update
+    updateGameOptimistically(game.id, {
+      disabled_at: isDisabled ? null : new Date().toISOString(),
+      reserved_at: isDisabled ? game.reserved_at : null, // Release if disabling
+      reserved_minutes: isDisabled ? game.reserved_minutes : null,
+    });
 
-  async function onGameStatsClick(location, game) {
     try {
-      const stats = await API.games.getStats(location.id, game.id);
-      setGameStats(stats);
-      setModalGameStatsShow(true);
+      if (isDisabled) {
+        await API.games.enable(selectedLocation.id, game.id);
+      } else {
+        if (isReserved) {
+          await API.games.release(selectedLocation.id, game.id);
+        }
+        await API.games.disable(selectedLocation.id, game.id);
+      }
     } catch (error) {
-      console.error('Error fetching game stats:', error);
-      // Optionally show an error message to the user
+      showError(`Failed to ${isDisabled ? 'enable' : 'disable'} game`, error);
     }
-  }
+    // Always sync with server — correctly handles partial failures
+    await fetchGames();
+  }, [selectedLocation, updateGameOptimistically, fetchGames, showError]);
+
+  // Handler: Remove game
+  const handleRemoveGame = React.useCallback((game) => {
+    if (!selectedLocation) return;
+
+    showConfirmation({
+      title: 'Remove Game',
+      message: `Are you sure you want to remove ${game.name}?`,
+      confirmText: 'Remove',
+      variant: 'danger',
+      onConfirm: async () => {
+        const location = selectedLocationRef.current;
+        if (!location) return;
+        try {
+          await API.games.remove(location.id, game.id);
+          await fetchGames();
+          showSuccess('Game removed successfully');
+        } catch (error) {
+          showError('Failed to remove game', error);
+        }
+      },
+    });
+  }, [selectedLocation, fetchGames, showConfirmation, showSuccess, showError]);
+
+  // Handler: Show game details
+  const handleShowDetails = React.useCallback(async (game) => {
+    if (!selectedLocation) return;
+
+    try {
+      const details = await API.games.get(selectedLocation.id, game.id);
+      setGameDetails(details);
+      gameDetailsModal.open();
+    } catch (error) {
+      showError('Failed to load game details', error);
+    }
+  }, [selectedLocation, gameDetailsModal, showError]);
+
+  // Handler: Show game stats
+  const handleShowStats = React.useCallback(async (game) => {
+    if (!selectedLocation) return;
+
+    try {
+      const stats = await API.games.getStats(selectedLocation.id, game.id);
+      setGameStats(stats);
+      gameStatsModal.open();
+    } catch (error) {
+      showError('Failed to load game statistics', error);
+    }
+  }, [selectedLocation, gameStatsModal, showError]);
+
+  // Handler: Add note to game
+  const handleAddNote = React.useCallback(async (noteText) => {
+    if (!selectedLocation || !gameDetails) return;
+
+    try {
+      const newNote = await API.notes.add(selectedLocation.id, gameDetails.id, noteText);
+      setGameDetails((prev) => {
+        if (!prev) return prev;
+        return { ...prev, notes: [...(prev.notes || []), newNote] };
+      });
+      showSuccess('Note added successfully');
+    } catch (error) {
+      showError('Failed to add note', error);
+      throw error;
+    }
+  }, [selectedLocation, gameDetails, showSuccess, showError]);
+
+  // Handler: Delete note from game
+  const handleDeleteNote = React.useCallback(async (noteId) => {
+    if (!selectedLocation || !gameDetails) return;
+
+    try {
+      await API.notes.remove(selectedLocation.id, gameDetails.id, noteId);
+      setGameDetails((prev) => {
+        if (!prev) return prev;
+        return { ...prev, notes: prev.notes.filter((note) => note.id !== noteId) };
+      });
+      showSuccess('Note deleted successfully');
+    } catch (error) {
+      showError('Failed to delete note', error);
+    }
+  }, [selectedLocation, gameDetails, showSuccess, showError]);
+
+  // Handler: Randomize game selection
+  const handleRandomize = React.useCallback(async () => {
+    if (!selectedLocation) return;
+
+    try {
+      const game = await API.games.reserveRandom(selectedLocation.id);
+      setReservedGame(game);
+      // Refresh games list since we don't know which one was reserved
+      await fetchGames();
+      showSuccess(`Reserved ${game.name}!`);
+    } catch (error) {
+      showError('Failed to reserve random game', error);
+    }
+  }, [selectedLocation, fetchGames, showSuccess, showError]);
+
+  // Handler: Close game details modal
+  const handleCloseGameDetails = React.useCallback(() => {
+    gameDetailsModal.close();
+  }, [gameDetailsModal]);
+
+  const handleGameDetailsExited = React.useCallback(() => {
+    setGameDetails(null);
+  }, []);
+
+  // Handler: Close game stats modal
+  const handleCloseGameStats = React.useCallback(() => {
+    gameStatsModal.close();
+  }, [gameStatsModal]);
+
+  const handleGameStatsExited = React.useCallback(() => {
+    setGameStats(null);
+  }, []);
 
   return (
     <div className="container-fluid">
+      {toastList}
+      {confirmationDialog}
+
       <header>
         <LocationPicker
-        locations={locations}
-        selectedLocation={selectedLocation}
-        onSelectLocationClick={onSelectLocationClick}
-        onAddLocationClick={onAddLocationClick}
-        onAddGameClick={onAddGameClick}
+          locations={locations}
+          selectedLocation={selectedLocation}
+          onSelectLocation={handleSelectLocation}
+          onAddLocation={addLocationModal.open}
+          onAddGame={addGameModal.open}
         />
       </header>
 
-      <div  className={selectedLocation ? 'visible': 'invisible'}>
+      <div className={selectedLocation ? 'visible' : 'invisible'}>
         <div className="text-center my-2">
-          <RandomizeButton
-            onRaffleClick={onRandomizeClick}
-          />
+          <RandomizeButton onClick={handleRandomize} disabled={gamesLoading} />
         </div>
         <div className="fixed-height-selected-game my-2">
-            <h3>
-              {reservedGame ? reservedGame.name : ''}
-            </h3>
+          <h3>{reservedGame ? reservedGame.name : ''}</h3>
         </div>
         <div>
           <GameList
-            gameStates={gameStates}
-            selectedLocation={selectedLocation}
-            onGameClick={onGameClick}
-            onToggleGameDisabledClick={onToggleGameDisabledClick}
-            onRemoveGameClick={onRemoveGameClick}
-            onGameDetailsClick={onGameDetailsClick}
-            onGameStatsClick={onGameStatsClick}
+            games={games}
+            loading={gamesLoading}
+            onGameClick={handleGameClick}
+            onToggleDisabled={handleToggleDisabled}
+            onRemove={handleRemoveGame}
+            onShowDetails={handleShowDetails}
+            onShowStats={handleShowStats}
           />
         </div>
       </div>
+
       <AddLocationModal
-        modalAddLocationShow={modalAddLocationShow}
-        setModalAddLocationShow={setModalAddLocationShow}
-        setLocations={setLocations}
-        setSelectedLocation={setSelectedLocation}
-        setReservedGame={setReservedGame}
+        show={addLocationModal.show}
+        onHide={addLocationModal.close}
+        onAddLocation={handleAddLocation}
       />
+
       <AddGameModal
-        modalAddGameShow={modalAddGameShow}
-        selectedLocation={selectedLocation}
-        setModalAddGameShow={setModalAddGameShow}
-        setGameStates={setGameStates}
+        show={addGameModal.show}
+        onHide={addGameModal.close}
+        onAddGame={handleAddGame}
       />
+
       <GameDetailsModal
-        gameDetails={gameDetails}
-        modalGameDetailsShow={modalGameDetailsShow}
-        setGameDetails={setGameDetails}
-        setModalGameDetailsShow={setModalGameDetailsShow}
-        selectedLocation={selectedLocation}
+        show={gameDetailsModal.show}
+        onHide={handleCloseGameDetails}
+        onExited={handleGameDetailsExited}
+        game={gameDetails}
+        onAddNote={handleAddNote}
+        onDeleteNote={handleDeleteNote}
       />
+
       <GameStatsModal
-        modalGameStatsShow={modalGameStatsShow}
-        setModalGameStatsShow={setModalGameStatsShow}
-        gameStats={gameStats}
+        show={gameStatsModal.show}
+        onHide={handleCloseGameStats}
+        onExited={handleGameStatsExited}
+        stats={gameStats}
       />
     </div>
   );
 }
 
+// Initialize React app
 const container = document.getElementById('root');
-const root = ReactDOM.createRoot(container);
+const root = createRoot(container);
 root.render(<Raffler />);

--- a/static/utils/formatting.js
+++ b/static/utils/formatting.js
@@ -1,0 +1,31 @@
+/**
+ * Format a duration in minutes to a human-readable string
+ * @param {number} minutes - Duration in minutes
+ * @returns {string} Formatted duration string
+ */
+export function formatDuration(minutes) {
+  const days = Math.floor(minutes / (24 * 60));
+  const hours = Math.floor((minutes % (24 * 60)) / 60);
+  const mins = minutes % 60;
+
+  const parts = [];
+  if (days > 0) parts.push(`${days} day${days === 1 ? '' : 's'}`);
+  if (hours > 0) parts.push(`${hours} hour${hours === 1 ? '' : 's'}`);
+  if (mins > 0) parts.push(`${mins} minute${mins === 1 ? '' : 's'}`);
+
+  if (parts.length === 0) return '0 minutes';
+  if (parts.length === 1) return parts[0];
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+  return `${parts[0]}, ${parts[1]} and ${parts[2]}`;
+}
+
+/**
+ * Format a timestamp to a date and time string
+ * @param {string} timestamp - ISO timestamp
+ * @returns {string} Formatted date time string
+ */
+export function formatDateTime(timestamp) {
+  const [date, time] = timestamp.replace('T', ' ').split(' ');
+  const [hour, minute] = time.split(':');
+  return `${date} ${hour}:${minute}`;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  root: 'static',
+  publicDir: 'public',
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true,
+    copyPublicDir: true,
+  },
+  server: {
+    proxy: {
+      '/v1': 'http://localhost:8000'
+    }
+  }
+})


### PR DESCRIPTION
Replace in-browser Babel transpilation and vendored dependencies with a Vite build pipeline and npm-managed React 19 / React Bootstrap. The monolithic raffler.jsx is split into components, hooks, and utilities.

Key changes:
- Vite builds frontend to dist/, backend serves from dist/
- Relative API URLs (works on any host, not just localhost)
- Optimistic UI updates with server re-sync after mutations
- Toast notifications for errors
- Confirmation dialogs for destructive actions (game removal, note deletion)
- Note deletion from the UI
- Loading spinner, empty state messages, input validation
- GET request deduplication and configurable API timeouts