### PR TITLE
Use @stable ref for dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@1.87
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
 


### PR DESCRIPTION
Pinning to a specific Rust version like 1.87 confuses Dependabot, which treats it as a decimal and "bumps" to 1.100 — a version that doesn't exist (latest stable is 1.95). Switching to @stable tracks current stable and gives Dependabot nothing to mis-parse.