### PR TITLE
Ignore eslint major bumps until eslint-plugin-react supports v10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      # eslint-plugin-react@7.37.5 peer-deps eslint up to ^9.7 only;
+      # remove this once the plugin adds v10 support.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
eslint-plugin-react@7.37.5 (latest) peer-deps eslint up to ^9.7 only, so Dependabot's eslint v10 bump fails npm ci with ERESOLVE. Ignore major eslint updates until the plugin catches up; comment marks the trigger to remove the rule.